### PR TITLE
add disassembly command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ thiserror = "1.0.63"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"
 dirs = "4.0" # For easily getting the home directory
+solana_rbpf = "0.8.5"

--- a/src/commands/disassemble.rs
+++ b/src/commands/disassemble.rs
@@ -1,0 +1,55 @@
+use anyhow::{Error, Result};
+use solana_rbpf::{
+    elf::Executable, program::BuiltinProgram, static_analysis::Analysis, vm::TestContextObject,
+};
+
+use std::fs::File;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+pub fn disassemble(path: Option<String>, outfile: Option<String>) -> Result<()> {
+    let path = path.ok_or_else(|| Error::msg("Path not provided"))?;
+    let path = Path::new(&path);
+
+    // Ensure the path points to a valid .so binary
+    if path.extension().and_then(|ext| ext.to_str()) != Some("so") {
+        return Err(Error::msg("Invalid file path. Expected .so file"));
+    }
+
+    let mut file = File::open(path)?;
+    let mut buffer = Vec::new();
+    file.read_to_end(&mut buffer)?;
+
+    let program: &'static [u8] = Box::leak(buffer.into_boxed_slice());
+
+    let loader = Arc::new(BuiltinProgram::new_mock());
+    let executable = Executable::<TestContextObject>::from_elf(program, loader).unwrap();
+    let analysis = Analysis::from_executable(&executable).unwrap();
+    let stdout = std::io::stdout();
+
+    analysis.disassemble(&mut stdout.lock())?;
+
+    match outfile {
+        Some(outpath) => {
+            let outpath = ensure_asm_extension(outpath);
+            let mut file = File::create(outpath)?;
+            analysis.disassemble(&mut file)?;
+        }
+        None => {
+            let stdout = std::io::stdout();
+            analysis.disassemble(&mut stdout.lock())?;
+        }
+    }
+
+    Ok(())
+}
+
+fn ensure_asm_extension(path: String) -> PathBuf {
+    let path = PathBuf::from(path);
+    if path.extension().and_then(|ext| ext.to_str()) != Some("s") {
+        path.with_extension("s")
+    } else {
+        path
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -13,4 +13,7 @@ pub use test::*;
 pub mod clean;
 pub use clean::*;
 
+pub mod disassemble;
+pub use disassemble::*;
+
 pub mod common;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 pub mod commands;
 use anyhow::Error;
 use clap::{Args, Parser, Subcommand};
-use commands::{build, clean, deploy, init, test};
+use commands::{build, clean, deploy, disassemble, init, test};
 
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
@@ -25,6 +25,8 @@ enum Commands {
     E2E(DeployArgs),
     #[command(about = "Clean up build and deploy artifacts")]
     Clean,
+    #[command(about = "Disassemble a compiled program")]
+    Disassemble(DisassembleArgs),
 }
 
 #[derive(Args)]
@@ -36,6 +38,13 @@ struct InitArgs {
 struct DeployArgs {
     name: Option<String>,
     url: Option<String>,
+}
+
+#[derive(Args)]
+struct DisassembleArgs {
+    path: Option<String>,
+    #[arg(short = 'o', long = "output")]
+    outfile: Option<String>,
 }
 
 fn main() -> Result<(), Error> {
@@ -52,5 +61,6 @@ fn main() -> Result<(), Error> {
             test()
         }
         Commands::Clean => clean(),
+        Commands::Disassemble(args) => disassemble(args.path.clone(), args.outfile.clone()),
     }
 }


### PR DESCRIPTION
Adds a command to disassemble a given binary and output raw asm, with the option to specify a .s outfile for further analysis

### Todos
- Leverage ezbpf & rbpf tooling further to provide json outputs
- Visual analysis

### Testing Steps

- [ ] Run `cargo build`
- [ ] Navigate to `target/debug`
- [ ] Run `./sbpf disassemble <path-to-binary> -o <outfile-path>`