### PR TITLE
Enhance Project Initialization to Use Mollusk as Default Testing Tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+## Table of Contents
+
+-   [sbpf](#sbpf)
+-   [Dependencies](#dependencies)
+-   [Installation](#installation)
+-   [Usage](#usage)
+-   [Command Details](#command-details)
+-   [Examples](#examples)
+-   [Advanced Usage](#advanced-usage)
+-   [Contributing](#contributing)
+
 # sbpf
 
 A simple scaffold to bootstrap sBPF Assembly programs.
@@ -7,12 +18,22 @@ A simple scaffold to bootstrap sBPF Assembly programs.
 Please make sure you have the latest version of [Solana Command Line Tools](https://docs.solanalabs.com/cli/install) installed.
 
 ### Installation
+
 ```sh
 cargo install --git https://github.com/deanmlittle/sbpf.git
 ```
 
 ### Usage
-To view all the commands you can run, type `sbpf help`
+
+To view all the commands you can run, type `sbpf help`. Here are the available commands:
+
+-   `init`: Create a new project scaffold.
+-   `build`: Compile into a Solana program executable.
+-   `deploy`: Build and deploy the program.
+-   `test`: Test the deployed program.
+-   `e2e`: Build, deploy, and test a program.
+-   `clean`: Clean up build and deploy artifacts.
+-   `help`: Print this message or the help of the given subcommand(s).
 
 ```
 Usage: sbpf <COMMAND>
@@ -30,6 +51,43 @@ Options:
   -h, --help     Print help
   -V, --version  Print version
 ```
+
+### Command Details
+
+#### Initialize a Project
+
+To create a new project, use the `sbpf init` command. By default, it initializes a project with Rust tests using [Mollusk](https://github.com/buffalojoec/mollusk). You can also initialize a project with TypeScript tests using the `--ts-tests` option.
+
+```sh
+sbpf init --help
+Create a new project scaffold
+
+Usage: sbpf init [OPTIONS] [NAME]
+
+Arguments:
+  [NAME]  The name of the project to create
+
+Options:
+  -t, --ts-tests  Initialize with TypeScript tests instead of Mollusk Rust tests
+  -h, --help      Print help information
+  -V, --version   Print version information
+```
+
+##### Examples
+
+###### Create a new project with Rust tests (default)
+
+```sh
+sbpf init my-project
+```
+
+###### Create a new project with TypeScript tests
+
+```sh
+sbpf init my-project --ts-tests
+```
+
+After initializing the project, you can navigate into the project directory and use other commands to build, deploy, and test your program.
 
 ### Advanced Usage
 

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -1,11 +1,11 @@
+use anyhow::{Error, Result};
+use dirs::home_dir;
+use std::fs;
 use std::fs::create_dir_all;
 use std::io;
 use std::path::Path;
 use std::process::Command;
 use std::time::Instant;
-use std::fs;
-use anyhow::{Result, Error};
-use dirs::home_dir;
 
 use crate::commands::common::{SolanaConfig, DEFAULT_LINKER};
 
@@ -16,24 +16,28 @@ pub fn build() -> Result<()> {
     let config_path = home_dir.join(".config/solana/install/config.yml");
 
     if !Path::new(&config_path).exists() {
-        return Err(Error::msg("❌ Solana config not found. Please install the Solana CLI:\n\nhttps://docs.solanalabs.com/cli/install"))
+        return Err(Error::msg("❌ Solana config not found. Please install the Solana CLI:\n\nhttps://docs.solanalabs.com/cli/install"));
     }
 
     // Read the file contents
     let config_content = fs::read_to_string(config_path)?;
-    
+
     // Parse the YAML file
     let solana_config: SolanaConfig = serde_yaml::from_str(&config_content)?;
 
     // Solana SDK and toolchain paths
-    let platform_tools = [solana_config.active_release_dir, "/bin/sdk/sbf/dependencies/platform-tools".to_owned()].concat();
+    let platform_tools = [
+        solana_config.active_release_dir,
+        "/bin/sdk/sbf/dependencies/platform-tools".to_owned(),
+    ]
+    .concat();
     let llvm_dir = [platform_tools.clone(), "/llvm".to_owned()].concat();
     let clang = [llvm_dir.clone(), "/bin/clang".to_owned()].concat();
     let ld = [llvm_dir.clone(), "/bin/ld.lld".to_owned()].concat();
 
     // Check for platform tools
     if !Path::new(&llvm_dir).exists() {
-        return Err(Error::msg(format!("❌ Solana platform-tools not found. To manually install, please download the latest release here: \n\nhttps://github.com/anza-xyz/platform-tools/releases\n\nThen unzip to this directory and try again:\n\n{}", &platform_tools)))
+        return Err(Error::msg(format!("❌ Solana platform-tools not found. To manually install, please download the latest release here: \n\nhttps://github.com/anza-xyz/platform-tools/releases\n\nThen unzip to this directory and try again:\n\n{}", &platform_tools)));
     }
 
     // Set src/out directory and compiler flags
@@ -92,7 +96,7 @@ pub fn build() -> Result<()> {
         // Check if a custom linker file exists
         if !Path::new(&linker_file).exists() {
             if !Path::new(&default_linker).exists() {
-                fs::create_dir(".sbpf").unwrap_or( ());
+                fs::create_dir(".sbpf").unwrap_or(());
                 fs::write(&default_linker, DEFAULT_LINKER)?;
             }
             linker_file = default_linker;

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -2,11 +2,11 @@ use serde::Deserialize;
 
 #[derive(Deserialize, Debug)]
 pub struct SolanaConfig {
-  pub releases_dir: String,
-  pub active_release_dir: String,
+    pub releases_dir: String,
+    pub active_release_dir: String,
 }
 
-pub const DEFAULT_PROGRAM: &str = r#".globl entrypoint
+pub const PROGRAM: &str = r#".globl entrypoint
 entrypoint:
     lddw r1, message
     lddw r2, 14
@@ -81,7 +81,7 @@ pub const PACKAGE_JSON: &str = r#"{
 }
 "#;
 
-pub const TESTS: &str = r#"
+pub const TS_TESTS: &str = r#"
 import { Connection, Keypair, Transaction, TransactionInstruction } from "@solana/web3.js"
 import programSeed from "../deploy/default_project_name-keypair.json"
 
@@ -146,3 +146,47 @@ pub const TSCONFIG: &str = r#"
     }
 }
 "#;
+
+pub const CARGO_TOML: &str = r#"[package]
+name = "default_project_name"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[dev-dependencies]
+mollusk-svm = "0.0.11"
+solana-sdk = "2.1.0"
+
+[features]
+test-sbf = []"#;
+
+pub const RUST_TESTS: &str = r#"#[cfg(test)]
+mod tests {
+    use mollusk_svm::{result::Check, Mollusk};
+    use solana_sdk::{instruction::Instruction, pubkey::Pubkey};
+
+    #[test]
+    fn test_hello_world() {
+        let program_id_keypair_bytes = std::fs::read("deploy/default_project_name-keypair.json").unwrap()
+            [..32]
+            .try_into()
+            .expect("slice with incorrect length");
+        let program_id = Pubkey::new_from_array(program_id_keypair_bytes);
+
+        let instruction = Instruction::new_with_bytes(
+            program_id,
+            &[],
+            vec![]
+        );
+
+        let mollusk = Mollusk::new(&program_id, "deploy/default_project_name");
+
+        let result = mollusk.process_and_validate_instruction(
+            &instruction,
+            &[],
+            &[Check::success()]
+        );
+        assert!(!result.program_result.is_err());
+    }
+}"#;

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -33,7 +33,6 @@ pub fn init(name: Option<String>, ts_tests: bool) -> Result<(), Error> {
         fs::create_dir_all(&project_path)?;
         fs::create_dir_all(project_path.join("src").join(&project_name))?;
         fs::create_dir_all(project_path.join("deploy"))?;
-        fs::create_dir_all(project_path.join("tests"))?;
 
         fs::write(
             project_path.join("README.md"),
@@ -63,6 +62,7 @@ pub fn init(name: Option<String>, ts_tests: bool) -> Result<(), Error> {
                 PACKAGE_JSON.replace("default_project_name", &project_name),
             )?;
             fs::write(project_path.join("tsconfig.json"), TSCONFIG)?;
+            fs::create_dir_all(project_path.join("tests"))?;
             fs::write(
                 project_path
                     .join("tests")
@@ -77,10 +77,6 @@ pub fn init(name: Option<String>, ts_tests: bool) -> Result<(), Error> {
         } else {
             fs::write(
                 project_path.join("src").join("lib.rs"),
-                "// src/lib.rs is required for Rust tests\n",
-            )?;
-            fs::write(
-                project_path.join("tests").join("lib.rs"),
                 RUST_TESTS.replace("default_project_name", &project_name),
             )?;
             fs::write(

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,16 +1,16 @@
-use crate::commands::common::TESTS;
-
-use super::common::{DEFAULT_PROGRAM, GITIGNORE, PACKAGE_JSON, README, TSCONFIG};
+use super::common::{
+    CARGO_TOML, GITIGNORE, PACKAGE_JSON, PROGRAM, README, RUST_TESTS, TSCONFIG, TS_TESTS,
+};
 use anyhow::{Error, Result};
 use ed25519_dalek::SigningKey;
 use rand::rngs::OsRng;
 use std::fs;
 use std::io::{self, Write};
-use std::path::Path;
+use std::process::Command;
 
-pub fn init(name: Option<String>) -> Result<(), Error> {
+pub fn init(name: Option<String>, ts_tests: bool) -> Result<(), Error> {
     let project_name = match name {
-        Some(name) => name,
+        Some(name) => name.clone(),
         None => loop {
             print!("What is the name of your project? ");
             io::stdout().flush()?;
@@ -25,34 +25,30 @@ pub fn init(name: Option<String>) -> Result<(), Error> {
             }
         },
     };
-    let project_path = Path::new(&project_name);
+
+    let current_dir = std::env::current_dir()?;
+    let project_path = current_dir.join(&project_name);
 
     if !project_path.exists() {
-        // Create project path and subdirectories
+        fs::create_dir_all(&project_path)?;
         fs::create_dir_all(project_path.join("src").join(&project_name))?;
-        fs::create_dir(project_path.join("deploy"))?;
-        fs::create_dir(project_path.join("tests"))?;
+        fs::create_dir_all(project_path.join("deploy"))?;
+        fs::create_dir_all(project_path.join("tests"))?;
 
-        // Create Readme
         fs::write(
             project_path.join("README.md"),
             README.replace("default_project_name", &project_name),
         )?;
-        // Create .gitignore
         fs::write(project_path.join(".gitignore"), GITIGNORE)?;
 
-        // Create test
         fs::write(
-            project_path.join(format!("tests/{}.test.ts", project_name)),
-            TESTS.replace("default_project_name", &project_name),
+            project_path
+                .join("src")
+                .join(&project_name)
+                .join(format!("{}.s", project_name)),
+            PROGRAM,
         )?;
 
-        // Create default program
-        fs::write(
-            project_path.join(format!("src/{}/{}.s", project_name, project_name)),
-            DEFAULT_PROGRAM,
-        )?;
-        // Create deploy keypair
         let mut rng = OsRng;
         fs::write(
             project_path
@@ -60,14 +56,44 @@ pub fn init(name: Option<String>) -> Result<(), Error> {
                 .join(format!("{}-keypair.json", project_name)),
             serde_json::json!(SigningKey::generate(&mut rng).to_keypair_bytes()[..]).to_string(),
         )?;
-        // Create package.json
-        fs::write(
-            project_path.join("package.json"),
-            PACKAGE_JSON.replace("default_project_name", &project_name),
-        )?;
-        // Create tsconfig.json
-        fs::write(project_path.join("tsconfig.json"), TSCONFIG)?;
-        println!("✅ Project '{}' initialized successfully!", project_name);
+
+        if ts_tests {
+            fs::write(
+                project_path.join("package.json"),
+                PACKAGE_JSON.replace("default_project_name", &project_name),
+            )?;
+            fs::write(project_path.join("tsconfig.json"), TSCONFIG)?;
+            fs::write(
+                project_path
+                    .join("tests")
+                    .join(format!("{}.test.ts", project_name)),
+                TS_TESTS.replace("default_project_name", &project_name),
+            )?;
+
+            Command::new("yarn")
+                .current_dir(&project_path)
+                .arg("install")
+                .status()?;
+        } else {
+            fs::write(
+                project_path.join("src").join("lib.rs"),
+                "// src/lib.rs is required for Rust tests\n",
+            )?;
+            fs::write(
+                project_path.join("tests").join("lib.rs"),
+                RUST_TESTS.replace("default_project_name", &project_name),
+            )?;
+            fs::write(
+                project_path.join("Cargo.toml"),
+                CARGO_TOML.replace("default_project_name", &project_name),
+            )?;
+        }
+
+        println!(
+            "✅ Project '{}' initialized successfully with {} tests",
+            project_name,
+            if ts_tests { "TypeScript" } else { "Rust" }
+        );
         Ok(())
     } else {
         println!("⚠️ Project '{}' already exists!", project_name);

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -9,16 +9,14 @@ pub fn test() -> Result<(), Error> {
     fn has_so_files(dir: &Path) -> bool {
         if dir.exists() && dir.is_dir() {
             match fs::read_dir(dir) {
-                Ok(entries) => entries
-                    .filter_map(Result::ok)
-                    .any(|entry| {
-                        entry
-                            .path()
-                            .extension()
-                            .and_then(|ext| ext.to_str())
-                            .map(|ext| ext == "so")
-                            .unwrap_or(false)
-                    }),
+                Ok(entries) => entries.filter_map(Result::ok).any(|entry| {
+                    entry
+                        .path()
+                        .extension()
+                        .and_then(|ext| ext.to_str())
+                        .map(|ext| ext == "so")
+                        .unwrap_or(false)
+                }),
                 Err(_) => false,
             }
         } else {
@@ -52,6 +50,8 @@ pub fn test() -> Result<(), Error> {
             }
         }
         (false, true) => {
+            crate::commands::deploy(None, None)?;
+
             let status = Command::new("yarn").arg("test").status()?;
 
             if !status.success() {

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -1,19 +1,46 @@
-use std::io;
-use std::process::Command;
-
 use anyhow::{Error, Result};
+use std::{io, path::Path, process::Command};
 
 pub fn test() -> Result<(), Error> {
     println!("🧪 Running tests");
 
-    let status = Command::new("yarn").arg("test").status()?;
+    let has_cargo = Path::new("Cargo.toml").exists();
+    let has_package_json = Path::new("package.json").exists();
 
-    if !status.success() {
-        eprintln!("Failed to run tests");
-        return Err(Error::new(io::Error::new(
-            io::ErrorKind::Other,
-            "❌ Test failed",
-        )));
+    match (has_cargo, has_package_json) {
+        (true, _) => {
+            let output = Command::new("cargo")
+                .arg("test-sbf")
+                .env("RUST_BACKTRACE", "1")
+                .status()?;
+
+            if !output.success() {
+                eprintln!("Failed to run Rust tests");
+                return Err(Error::new(io::Error::new(
+                    io::ErrorKind::Other,
+                    "❌ Rust tests failed",
+                )));
+            }
+        }
+        (false, true) => {
+            let status = Command::new("yarn").arg("test").status()?;
+
+            if !status.success() {
+                eprintln!("Failed to run tests");
+                return Err(Error::new(io::Error::new(
+                    io::ErrorKind::Other,
+                    "❌ Test failed",
+                )));
+            }
+        }
+        (false, false) => {
+            return Err(Error::new(io::Error::new(
+                io::ErrorKind::NotFound,
+                "❌ No test configuration found. Expected either Cargo.toml or package.json",
+            )));
+        }
     }
+
+    println!("✅ Tests completed successfully!");
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,8 +28,14 @@ enum Commands {
 }
 
 #[derive(Args)]
-struct InitArgs {
+pub struct InitArgs {
     name: Option<String>,
+    #[arg(
+        short,
+        long = "ts-tests",
+        help = "Initialize with TypeScript tests instead of Mollusk Rust tests"
+    )]
+    ts_tests: bool,
 }
 
 #[derive(Args)]
@@ -42,7 +48,7 @@ fn main() -> Result<(), Error> {
     let cli = Cli::parse();
 
     match &cli.command {
-        Commands::Init(args) => init(args.name.clone()),
+        Commands::Init(args) => init(args.name.clone(), args.ts_tests),
         Commands::Build => build(),
         Commands::Deploy(args) => deploy(args.name.clone(), args.url.clone()),
         Commands::Test => test(),


### PR DESCRIPTION
This pull request introduces enhancements to the project initialization process within the `sbpf` scaffold. The key changes include:
- **Default Testing Tool**: Updated the project initialization command to set Mollusk as the default testing tool for Rust projects.
- **Documentation Updates**: Modified the README.md to reflect the new default behavior, ensuring that users are informed about the use of Mollusk for testing. This includes examples and explanations of how to utilize each testing tool.