### PR TITLE
add flag to compile assembly in debug mode

### DIFF
--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -26,7 +26,7 @@ pub fn test() -> Result<(), Error> {
 
     if !has_so_files(deploy_dir) {
         println!("🔄 No .so files found in 'deploy' directory. Running build...");
-        crate::commands::build::build()?;
+        crate::commands::build::build(false)?;
     }
 
     let has_cargo = Path::new("Cargo.toml").exists();

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ enum Commands {
     #[command(about = "Create a new project scaffold")]
     Init(InitArgs),
     #[command(about = "Compile into a Solana program executable")]
-    Build,
+    Build(BuildArgs),
     #[command(about = "Build and deploy the program")]
     Deploy(DeployArgs),
     #[command(about = "Test deployed program")]
@@ -44,16 +44,26 @@ struct DeployArgs {
     url: Option<String>,
 }
 
+#[derive(Args, Default)]
+struct BuildArgs {
+    #[arg(
+        short,
+        long = "debug",
+        help = "Build program in debug mode"
+    )]
+    debug: bool
+}
+
 fn main() -> Result<(), Error> {
     let cli = Cli::parse();
 
     match &cli.command {
         Commands::Init(args) => init(args.name.clone(), args.ts_tests),
-        Commands::Build => build(),
+        Commands::Build(args) => build(args.debug),
         Commands::Deploy(args) => deploy(args.name.clone(), args.url.clone()),
         Commands::Test => test(),
         Commands::E2E(args) => {
-            build()?;
+            build(false)?;
             deploy(args.name.clone(), args.url.clone())?;
             test()
         }


### PR DESCRIPTION
### Summary

This PR adds an optional flag (`--debug`) to the build command to include debug symbols when compiling the assembly file. I'm using it to experiment with debugging and thought I'd open a PR just in case it's useful. 

Please feel free to close it if it's not relevant.